### PR TITLE
Add Python3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ def get_email(package):
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 

--- a/tapioca_harvest/__init__.py
+++ b/tapioca_harvest/__init__.py
@@ -5,4 +5,4 @@ __email__ = 'de.ericson@gmail.com'
 __version__ = '0.1'
 
 
-from tapioca_harvest import Harvest
+from .tapioca_harvest import Harvest

--- a/tapioca_harvest/tapioca_harvest.py
+++ b/tapioca_harvest/tapioca_harvest.py
@@ -6,7 +6,7 @@ from tapioca import (
 from requests.auth import HTTPBasicAuth
 
 
-from resource_mapping import RESOURCE_MAPPING
+from .resource_mapping import RESOURCE_MAPPING
 
 
 class HarvestClientAdapter(JSONAdapterMixin, TapiocaAdapter):


### PR DESCRIPTION
This PR corrects the #2 issue by:

- Adding parentheses to the print function call on setup

- Using `.` for relative imports